### PR TITLE
Fix build macro issue

### DIFF
--- a/main/stepper_motor_encoder.c
+++ b/main/stepper_motor_encoder.c
@@ -27,7 +27,6 @@ typedef struct {
     rmt_symbol_word_t curve_table[];
 } rmt_stepper_curve_encoder_t;
 
-RMT_ENCODER_FUNC_ATTR
 static size_t rmt_encode_stepper_motor_curve(rmt_encoder_t *encoder, rmt_channel_handle_t channel, const void *primary_data, size_t data_size, rmt_encode_state_t *ret_state)
 {
     rmt_stepper_curve_encoder_t *motor_encoder = __containerof(encoder, rmt_stepper_curve_encoder_t, base);
@@ -54,7 +53,6 @@ static esp_err_t rmt_del_stepper_motor_curve_encoder(rmt_encoder_t *encoder)
     return ESP_OK;
 }
 
-RMT_ENCODER_FUNC_ATTR
 static esp_err_t rmt_reset_stepper_motor_curve_encoder(rmt_encoder_t *encoder)
 {
     rmt_stepper_curve_encoder_t *motor_encoder = __containerof(encoder, rmt_stepper_curve_encoder_t, base);


### PR DESCRIPTION
## Summary
- remove undefined `RMT_ENCODER_FUNC_ATTR` macros from stepper motor encoder

## Testing
- `cmake -S . -B build` *(fails: include could not find requested file `/tools/cmake/project.cmake`)*

------
https://chatgpt.com/codex/tasks/task_e_68449f8021188323ac256a5d5c8e0285