### PR TITLE
Fix stepper motor init

### DIFF
--- a/main/motor_ops.c
+++ b/main/motor_ops.c
@@ -47,12 +47,12 @@ void stepper_motor_init(stepper_motor_t *motor, int gpio_dir, int gpio_step,
     motor->gpio_dir  = gpio_dir;
     motor->gpio_step = gpio_step;
 
-    gpio_config_t en_dir_gpio_config = {
+    gpio_config_t dir_gpio_config = {
         .mode = GPIO_MODE_OUTPUT,
         .intr_type = GPIO_INTR_DISABLE,
-        .pin_bit_mask = (1ULL << gpio_en) | (1ULL << gpio_dir),
+        .pin_bit_mask = (1ULL << gpio_dir),
     };
-    ESP_ERROR_CHECK(gpio_config(&en_dir_gpio_config));
+    ESP_ERROR_CHECK(gpio_config(&dir_gpio_config));
 
     rmt_tx_channel_config_t tx_chan_config = {
         .clk_src = RMT_CLK_SRC_DEFAULT,

--- a/main/motor_ops.h
+++ b/main/motor_ops.h
@@ -16,7 +16,6 @@
 #define STEP_MOTOR_RESOLUTION_HZ 1000000
 
 typedef struct {
-    int gpio_en;
     int gpio_dir;
     int gpio_step;
     rmt_channel_handle_t rmt_chan;
@@ -45,7 +44,7 @@ typedef enum {
 
 void setup_gpio_input(int gpio_num, bool pull_up, bool pull_down);
 void setup_gpio_output(int gpio_num);
-void stepper_motor_init(stepper_motor_t *motor, int gpio_en, int gpio_dir, int gpio_step,
+void stepper_motor_init(stepper_motor_t *motor, int gpio_dir, int gpio_step,
                         int start_freq_hz, int end_freq_hz, int accel_points,
                         int decel_points, int uniform_speed_hz);
 bool carrier_home(stepper_motor_t *motor, uint32_t *uniform_speed_hz, gpio_num_t limit_gpio);


### PR DESCRIPTION
## Summary
- clean up stepper motor structure and init
- remove unused enable pin argument

## Testing
- `idf.py build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688416a468148323b42bcf2f2906d1a0