### PR TITLE
Fix TCS3472 integration

### DIFF
--- a/main/motor_ops.c
+++ b/main/motor_ops.c
@@ -134,19 +134,22 @@ void tap_sequence(stepper_motor_t *motor, uint32_t *uniform_speed_hz, const tapt
         }
     };
     bool direction = !cfg->direction;
-    gpio_set_level(motor->gpio_dir,
-                       direction);
+    gpio_set_level(motor->gpio_dir, direction);
     uint32_t n_steps = 1;
     tx_config.loop_count = 4000;
     ESP_ERROR_CHECK(rmt_transmit(motor->rmt_chan, motor->uniform_encoder,
                                 uniform_speed_hz, n_steps * sizeof(uint32_t), &tx_config));
     ESP_ERROR_CHECK(rmt_tx_wait_all_done(motor->rmt_chan, -1));
+
+    // Initialize the colour sensor once before scanning
+    ESP_ERROR_CHECK(tcs3472_init(I2C_PORT, I2C_SDA, I2C_SCL));
+
     for (int j = 0; j < 5 && !stop_requested; j++) {
-        gpio_set_level(motor->gpio_dir,
-                       direction);
-        
+        gpio_set_level(motor->gpio_dir, direction);
+
         for (int i = 0; i < (cfg->blade_width / 10) && !stop_requested; i++) {
-            if( (gpio_get_level(cfg->limit_switch) == 1) &&(i>1&&i<0.9*cfg->blade_lenght/10)) {
+            if ((gpio_get_level(cfg->limit_switch) == 1) &&
+                (i > 1 && i < 0.9 * cfg->blade_lenght / 10)) {
                 ESP_LOGI("StepperMotor", "End limit switch triggered, stopping tap sequence.");
                 break;
             }
@@ -157,17 +160,15 @@ void tap_sequence(stepper_motor_t *motor, uint32_t *uniform_speed_hz, const tapt
             ESP_ERROR_CHECK(rmt_tx_wait_all_done(motor->rmt_chan, -1));
             float x_coord = (float)j; // Taken as an incremented index for now
             float y_coord = (float)(direction ? i * 10 : (int)(cfg->blade_width - i * 10));
-            record_sample(100, "T", x_coord, y_coord); // Call record_sample, swap the placeholder values for actual coordinates to save where the data was taken as part of the filename
+            record_sample(100, "T", x_coord, y_coord); // Record where the data was taken
 
-            //Record colour
-                        //Record colour
-            ESP_ERROR_CHECK(tcs3472_init(I2C_PORT, I2C_SDA, I2C_SCL));
+            // Record colour
             tcs3472_rgbc_data_t color_data;
             if (tcs3472_read_colors(&color_data) == ESP_OK) {
-                const char* color = tcs3472_detect_color(color_data);
+                const char *color = tcs3472_detect_color(color_data);
                 printf("Detected color: %s (R:%d G:%d B:%d C:%d)\n", color,
-                    color_data.r, color_data.g, color_data.b, color_data.c);
-
+                       color_data.r, color_data.g, color_data.b, color_data.c);
+            }
 
             if (stop_requested) {
                 rmt_disable(motor->rmt_chan);
@@ -176,28 +177,24 @@ void tap_sequence(stepper_motor_t *motor, uint32_t *uniform_speed_hz, const tapt
                 return;
             }
         }
-    direction = !direction;
-    //Encoder and DC Driver movement
-    encoder_init(ENCODER_PIN_A, ENCODER_PIN_B);
-    motor_driver_init();
-    //Drive the motor to move 10 mm
-    float target_distance_mm = 10.0f;
-    //Direction, Forward is true, Reverse is false direction
-    bool spandir = true;
-    DCmotordrive(target_distance_mm, spandir);
-    //Print final distance
-    float final_distance = encoder_get_distance_mm();
-    int final_position = encoder_get_position();
-    ESP_LOGI("MAIN", "Target: %.2f mm", target_distance_mm);
-    ESP_LOGI("MAIN", "Final Position: %d counts", final_position);
-    ESP_LOGI("MAIN", "Final Distance: %.2f mm", final_distance);
-    //vTaskDelay(pdMS_TO_TICKS(cfg->recording_duration));
-    if (stop_requested) {
-        rmt_disable(motor->rmt_chan);
 
-        stop_requested = false;
-        return;
+        direction = !direction;
+
+        // Encoder and DC Driver movement
+        encoder_init(ENCODER_PIN_A, ENCODER_PIN_B);
+        motor_driver_init();
+        float target_distance_mm = 10.0f;
+        bool spandir = true;
+        DCmotordrive(target_distance_mm, spandir);
+        float final_distance = encoder_get_distance_mm();
+        int final_position = encoder_get_position();
+        ESP_LOGI("MAIN", "Target: %.2f mm", target_distance_mm);
+        ESP_LOGI("MAIN", "Final Position: %d counts", final_position);
+        ESP_LOGI("MAIN", "Final Distance: %.2f mm", final_distance);
+        if (stop_requested) {
+            rmt_disable(motor->rmt_chan);
+            stop_requested = false;
+            return;
+        }
     }
-    
-}
 }

--- a/main/tcs3472.c
+++ b/main/tcs3472.c
@@ -1,7 +1,6 @@
 #include "tcs3472.h"
 #include "esp_log.h"
 #include "freertos/task.h"
-#include "pin_config.h"
 #define TAG "TCS3472"
 
 #define TCS3472_ADDR 0x29
@@ -13,25 +12,31 @@
 #define CONTROL_REG 0x0F
 #define CDATAL 0x14
 
-static i2c_port_t i2c_port_used;
+static i2c_master_bus_handle_t i2c_bus;
+static i2c_master_dev_handle_t i2c_dev;
 
 static esp_err_t write_register(uint8_t reg, uint8_t value) {
     uint8_t data[2] = {TCS_CMD_BIT | reg, value};
-    return i2c_master_write_to_device(i2c_port_used, TCS3472_ADDR, data, 2, pdMS_TO_TICKS(100));
+    return i2c_master_transmit(i2c_dev, data, sizeof(data), -1);
 }
 
-esp_err_t tcs3472_init(i2c_port_t port, gpio_num_t sda, gpio_num_t scl) {
-    i2c_port_used = port;
-    i2c_config_t conf = {
-        .mode = I2C_MODE_MASTER,
+esp_err_t tcs3472_init(i2c_port_num_t port, gpio_num_t sda, gpio_num_t scl) {
+    i2c_master_bus_config_t bus_conf = {
+        .i2c_port = port,
         .sda_io_num = sda,
         .scl_io_num = scl,
-        .sda_pullup_en = GPIO_PULLUP_ENABLE,
-        .scl_pullup_en = GPIO_PULLUP_ENABLE,
-        .master.clk_speed = I2C_FREQ_HZ,
+        .clk_source = I2C_CLK_SRC_DEFAULT,
+        .glitch_ignore_cnt = 7,
+        .flags = {.enable_internal_pullup = true},
     };
-    ESP_ERROR_CHECK(i2c_param_config(port, &conf));
-    ESP_ERROR_CHECK(i2c_driver_install(port, I2C_MODE_MASTER, 0, 0, 0));
+    ESP_ERROR_CHECK(i2c_new_master_bus(&bus_conf, &i2c_bus));
+
+    i2c_device_config_t dev_conf = {
+        .dev_addr_length = I2C_ADDR_BIT_LEN_7,
+        .device_address = TCS3472_ADDR,
+        .scl_speed_hz = I2C_FREQ_HZ,
+    };
+    ESP_ERROR_CHECK(i2c_master_bus_add_device(i2c_bus, &dev_conf, &i2c_dev));
 
     vTaskDelay(pdMS_TO_TICKS(10));
     ESP_ERROR_CHECK(write_register(ENABLE_REG, 0x03));     // Power on, ADC enabled
@@ -45,7 +50,7 @@ esp_err_t tcs3472_read_colors(tcs3472_rgbc_data_t *data) {
     uint8_t reg = TCS_CMD_BIT | CDATAL;
     uint8_t buf[8];
 
-    esp_err_t err = i2c_master_write_read_device(i2c_port_used, TCS3472_ADDR, &reg, 1, buf, 8, pdMS_TO_TICKS(100));
+    esp_err_t err = i2c_master_transmit_receive(i2c_dev, &reg, 1, buf, 8, -1);
     if (err != ESP_OK) return err;
 
     data->c = buf[1] << 8 | buf[0];

--- a/main/tcs3472.h
+++ b/main/tcs3472.h
@@ -1,7 +1,7 @@
 #ifndef TCS3472_H
 #define TCS3472_H
 
-#include "driver/i2c.h"
+#include "driver/i2c_master.h"
 
 typedef struct {
     uint16_t r;
@@ -10,7 +10,7 @@ typedef struct {
     uint16_t c;
 } tcs3472_rgbc_data_t;
 
-esp_err_t tcs3472_init(i2c_port_t port, gpio_num_t sda, gpio_num_t scl);
+esp_err_t tcs3472_init(i2c_port_num_t port, gpio_num_t sda, gpio_num_t scl);
 esp_err_t tcs3472_read_colors(tcs3472_rgbc_data_t *data);
 const char* tcs3472_detect_color(tcs3472_rgbc_data_t data);
 


### PR DESCRIPTION
## Summary
- initialize TCS3472 once before scanning and read color data during tap sequence
- adapt sensor driver to ESP-IDF's new I2C master API

## Testing
- `idf.py build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68929adba5f483239f59284f0c79e35b