### PR TITLE
Complete motor and blade config refactor

### DIFF
--- a/main/main.c
+++ b/main/main.c
@@ -13,20 +13,12 @@
 
 void app_main(void) {
     stepper_motor_t motorbot;
-
-    int gpio_dir;
-    int gpio_step;
-    int limit_switch;
-    int tapper_gpio;
-    rmt_channel_handle_t rmt_chan;
-    rmt_encoder_handle_t accel_encoder;
-    rmt_encoder_handle_t uniform_encoder;
-    rmt_encoder_handle_t decel_encoder;
-    stepper_motor_init(&motorbot, 
+    stepper_motor_init(&motorbot,
                        STEP_MOTOR_GPIO_DIR,
                        STEP_MOTOR_GPIO_STEP,
-                       LIMIT_SWITCH_GPIO,
-                       
+                       TOP_END_LIMIT_GPIO,
+                       IN3,
+                       STEP_MOTOR_SPIN_DIR_CLOCKWISE,
                        500,
                        1500,
                        500,
@@ -49,7 +41,7 @@ void app_main(void) {
 
     uint32_t uniform_speed_hz = 5000;
 
-    taptest_blade_config side_cfg = {160, 340, 50, 1000, 1};
+    taptest_blade_config side_cfg = {160, 340, 50, 1000};
 
     state_t state = STATE_IDLE;
 
@@ -64,15 +56,15 @@ void app_main(void) {
 
             case STATE_TAPBOT_RESET:
                 ESP_LOGI("TapBot", "Resetting tapbot...");
-                carrier_home(&motorbot, &uniform_speed_hz, &side_cfg);
-                
+                carrier_home(&motorbot, &uniform_speed_hz);
+
                 ESP_LOGI("TapBot", "Resetting tapbot...");
                 state = STATE_IDLE;
                 break;
 
             case STATE_TAPTEST_SEQUENCE:
                 ESP_LOGI("Tap Test", "Homing carrier...");
-                carrier_home(&motorbot, &uniform_speed_hz, &side_cfg);
+                carrier_home(&motorbot, &uniform_speed_hz);
                 ESP_LOGI("Tap Test", "Starting tap sequence...");
                 tap_sequence(&motorbot, &uniform_speed_hz, &side_cfg);
                 state = STATE_IDLE;

--- a/main/motor_ops.c
+++ b/main/motor_ops.c
@@ -40,12 +40,16 @@ void setup_gpio_output(int gpio_num) {
 }
 
 void stepper_motor_init(stepper_motor_t *motor, int gpio_dir, int gpio_step,
+                        int limit_switch, int tapper_gpio, bool direction,
                         int start_freq_hz, int end_freq_hz,
                         int accel_points, int decel_points,
                         int uniform_speed_hz)
 {
     motor->gpio_dir  = gpio_dir;
     motor->gpio_step = gpio_step;
+    motor->limit_switch = limit_switch;
+    motor->tapper_gpio = tapper_gpio;
+    motor->direction = direction;
 
     gpio_config_t en_dir_gpio_config = {
         .pin_bit_mask = 1ULL << gpio_dir,
@@ -89,7 +93,7 @@ void stepper_motor_init(stepper_motor_t *motor, int gpio_dir, int gpio_step,
     ESP_ERROR_CHECK(rmt_enable(motor->rmt_chan));
 }
 
-bool carrier_home(stepper_motor_t *motor, uint32_t *uniform_speed_hz, const taptest_blade_config *bottom_side_cfg) {
+bool carrier_home(stepper_motor_t *motor, uint32_t *uniform_speed_hz) {
     if (gpio_get_level(motor->limit_switch) == 1) {
         ESP_LOGI("StepperMotor", "Limit switch already triggered, skipping homing.");
         return true;
@@ -126,14 +130,14 @@ bool carrier_home(stepper_motor_t *motor, uint32_t *uniform_speed_hz, const tapt
     return true;
 }
 
-void tap_sequence(stepper_motor_t *motor, uint32_t *uniform_speed_hz, const taptest_side_config *cfg) {
+void tap_sequence(stepper_motor_t *motor, uint32_t *uniform_speed_hz, const taptest_blade_config *cfg) {
     rmt_transmit_config_t tx_config = {
         .loop_count = 0,
         .flags = {
             .eot_level = 0
         }
     };
-    bool direction = !cfg->direction;
+    bool direction = !motor->direction;
     gpio_set_level(motor->gpio_dir, direction);
     uint32_t n_steps = 1;
     tx_config.loop_count = 4000;
@@ -148,7 +152,7 @@ void tap_sequence(stepper_motor_t *motor, uint32_t *uniform_speed_hz, const tapt
         gpio_set_level(motor->gpio_dir, direction);
 
         for (int i = 0; i < (cfg->blade_width / 10) && !stop_requested; i++) {
-            if ((gpio_get_level(cfg->limit_switch) == 1) &&
+            if ((gpio_get_level(motor->limit_switch) == 1) &&
                 (i > 1 && i < 0.9 * cfg->blade_lenght / 10)) {
                 ESP_LOGI("StepperMotor", "End limit switch triggered, stopping tap sequence.");
                 break;

--- a/main/motor_ops.h
+++ b/main/motor_ops.h
@@ -20,6 +20,7 @@ typedef struct {
     int gpio_step;
     int limit_switch;
     int tapper_gpio;
+    bool direction;
     rmt_channel_handle_t rmt_chan;
     rmt_encoder_handle_t accel_encoder;
     rmt_encoder_handle_t uniform_encoder;
@@ -43,10 +44,11 @@ typedef enum {
 void setup_gpio_input(int gpio_num, bool pull_up, bool pull_down);
 void setup_gpio_output(int gpio_num);
 void stepper_motor_init(stepper_motor_t *motor, int gpio_dir, int gpio_step,
+                        int limit_switch, int tapper_gpio, bool direction,
                         int start_freq_hz, int end_freq_hz, int accel_points,
                         int decel_points, int uniform_speed_hz);
-bool carrier_home(stepper_motor_t *motor, uint32_t *uniform_speed_hz, const taptest_side_config *side_cfg);
-void tap_sequence(stepper_motor_t *motor, uint32_t *uniform_speed_hz, const taptest_side_config *cfg);
+bool carrier_home(stepper_motor_t *motor, uint32_t *uniform_speed_hz);
+void tap_sequence(stepper_motor_t *motor, uint32_t *uniform_speed_hz, const taptest_blade_config *cfg);
 void IRAM_ATTR stop_button_isr_handler(void *arg);
 
 #endif // MOTOR_OPS_H


### PR DESCRIPTION
## Summary
- finish migration from side config to separate blade and motor settings
- initialize stepper motor with limit switch, tapper GPIO and direction
- simplify carrier homing and tap sequence to use new motor fields

## Testing
- `cmake -S . -B build` *(fails: include could not find requested file: /tools/cmake/project.cmake)*

------
https://chatgpt.com/codex/tasks/task_e_6892afaab55c8323aa2228f5f25fe3fa