### PR TITLE
Detect button release using rising-edge interrupts

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This repository contains a single `main.c` sketch that drives a small robot usin
 - **Two stepper motors** driven by DRV8825 drivers (step and direction lines only)
 - **Two DC motors** run for fixed durations (no encoders)
 - **Two solenoids** via single-pin control
-- **Three push buttons** (START, RESET, STOP) configured as interrupts
+- **Three push buttons** (START, RESET, STOP) configured as interrupts triggered on release (rising edge)
 - A `switch`/`enum` state machine (`IDLE`, `RESET`, `SEQUENCE`, `DONE`)
 
 ## Building

--- a/main.c
+++ b/main.c
@@ -254,9 +254,9 @@ void setup() {
     pinMode(START_BTN_PIN, INPUT_PULLUP);
     pinMode(RESET_BTN_PIN, INPUT_PULLUP);
     pinMode(STOP_BTN_PIN,  INPUT_PULLUP);
-    attachInterrupt(digitalPinToInterrupt(START_BTN_PIN), startButtonISR, FALLING);
-    attachInterrupt(digitalPinToInterrupt(RESET_BTN_PIN), resetButtonISR, FALLING);
-    attachInterrupt(digitalPinToInterrupt(STOP_BTN_PIN),  stopButtonISR,  FALLING);
+    attachInterrupt(digitalPinToInterrupt(START_BTN_PIN), startButtonISR, RISING);
+    attachInterrupt(digitalPinToInterrupt(RESET_BTN_PIN), resetButtonISR, RISING);
+    attachInterrupt(digitalPinToInterrupt(STOP_BTN_PIN),  stopButtonISR,  RISING);
 }
 
 // --- Main loop ---


### PR DESCRIPTION
## Summary
- Trigger start, reset, and stop button interrupts on rising edges
- Document rising-edge release behavior for button interrupts

## Testing
- `gcc -fsyntax-only main.c` *(fails: Arduino.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6895a4b88b6c8323a4d5c98880bffadb