### PR TITLE
Use falling edge for stop button interrupt

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This repository contains a single `main.c` sketch that drives a small robot usin
 - **Two stepper motors** driven by DRV8825 drivers (step and direction lines only)
 - **Two DC motors** run for fixed durations (no encoders)
 - **Two solenoids** via single-pin control
-- **Three push buttons** (START, RESET, STOP) configured as interrupts triggered on release (rising edge)
+- **Three push buttons** (START, RESET, STOP) using interrupts; START/RESET fire on release (rising edge) while STOP fires on press (falling edge)
 - A `switch`/`enum` state machine (`IDLE`, `RESET`, `SEQUENCE`, `DONE`)
 
 ## Building

--- a/main.c
+++ b/main.c
@@ -256,7 +256,8 @@ void setup() {
     pinMode(STOP_BTN_PIN,  INPUT_PULLUP);
     attachInterrupt(digitalPinToInterrupt(START_BTN_PIN), startButtonISR, RISING);
     attachInterrupt(digitalPinToInterrupt(RESET_BTN_PIN), resetButtonISR, RISING);
-    attachInterrupt(digitalPinToInterrupt(STOP_BTN_PIN),  stopButtonISR,  RISING);
+    // Trigger STOP on press (falling edge) to avoid spurious interrupts on release
+    attachInterrupt(digitalPinToInterrupt(STOP_BTN_PIN),  stopButtonISR,  FALLING);
 }
 
 // --- Main loop ---


### PR DESCRIPTION
## Summary
- Trigger STOP button interrupt on falling edge to avoid spurious releases
- Document START/RESET rising-edge and STOP falling-edge behavior

## Testing
- `arduino-cli compile --fqbn arduino:avr:uno .` *(fails: command not found)*
- `apt-get install -y arduino-cli` *(fails: Unable to locate package arduino-cli)*
- `curl -fsSL https://raw.githubusercontent.com/arduino/arduino-cli/master/install.sh | sh` *(fails: CONNECT tunnel failed, response 403)*


------
https://chatgpt.com/codex/tasks/task_e_6895a70a8888832386379a923dae6610